### PR TITLE
fix: add spreadscaler constraits to the base wadm manifest

### DIFF
--- a/wadm.yaml
+++ b/wadm.yaml
@@ -23,3 +23,11 @@ spec:
       properties:
         image: cosmonic.azurecr.io/httpserver_wormhole:0.6.2
         contract: wasmcloud:httpserver
+      traits:
+        - properties:
+            replicas: 1
+            spread:
+              - name: oncosmonic
+                requirements:
+                  cosmonic_managed: "true"
+          type: spreadscaler


### PR DESCRIPTION
## Primary Reviewer
@joonas 

## Feature or Problem
It looks like we forgot to add a spreadscaler constraint on the initial deploy for the wormhole provider. Without having that the base wadm manifest will be stuck reconciling until the first pull request is merged.

## Related Issues

<!---
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information

<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc.
--->

## Consumer Impact

<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing

<!---
Declare the testing information for this pull request
--->

### Unit Test(s)

<!---
Indicate if unit tests were added or modified, and if so, which ones
--->

### Acceptance or Integration

<!---
Indicate any changes or additions to the acceptance or integration test suite
--->

### Manual Verification

<!---
Mandatory. Indicate the steps that you took to verify that this pull request works
--->
